### PR TITLE
Object tagging naming improvements

### DIFF
--- a/aviator_object_tagging.yml
+++ b/aviator_object_tagging.yml
@@ -11,7 +11,7 @@ spruce:
         regexp: ".*yml"
     to: aviator_pipeline_object_tagging.yml
 fly:
-  name: pdm-object-tagging
+  name: object-tagging
   target: utility
   expose: true
   check_creds: true

--- a/ci/utility/groups.yml
+++ b/ci/utility/groups.yml
@@ -1,11 +1,11 @@
 groups:
-  - name: object-tagging
+  - name: pdm-object-tagging
     jobs:
-    - object-tagging-dev
-    - object-tagging-qa
-    - object-tagging-integration
-    - object-tagging-preprod
-    - object-tagging-production
+    - pdm-object-tagging-dev
+    - pdm-object-tagging-qa
+    - pdm-object-tagging-integration
+    - pdm-object-tagging-preprod
+    - pdm-object-tagging-production
     - rbac-csv-upload-dev
     - rbac-csv-upload-qa
     - rbac-csv-upload-integration

--- a/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
@@ -12,7 +12,7 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
 
-  - name: object-tagging-dev
+  - name: pdm-object-tagging-dev
     max_in_flight: 1
     serial: true
     plan:

--- a/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
@@ -19,7 +19,7 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
 
-  - name: object-tagging-integration
+  - name: pdm-object-tagging-integration
     max_in_flight: 1
     serial: true
     plan:

--- a/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
@@ -19,7 +19,7 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
 
-  - name: object-tagging-preprod
+  - name: pdm-object-tagging-preprod
     max_in_flight: 1
     serial: true
     plan:

--- a/ci/utility/jobs/tag-pdm/production-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/production-object-tagging.yml
@@ -19,7 +19,7 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
 
-  - name: object-tagging-production
+  - name: pdm-object-tagging-production
     max_in_flight: 1
     serial: true
     plan:

--- a/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
@@ -15,7 +15,7 @@ jobs:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
 
-  - name: object-tagging-qa
+  - name: pdm-object-tagging-qa
     max_in_flight: 1
     serial: true
     plan:


### PR DESCRIPTION
Generalise object-tagging pipeline.
Make a group / jobs per requirement of object tagging. Marking previous PDM jobs with PDM prefix.
Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>