### PR TITLE
Clive pipelines

### DIFF
--- a/aviator_object_tagging.yml
+++ b/aviator_object_tagging.yml
@@ -5,9 +5,13 @@ spruce:
     merge:
       - with_in: ci/utility/
         regexp: ".*yml"
+      - with_in: ci/utility/jobs/rbac-classification-upload/
+        regexp: ".*yml"
       - with_in: ci/utility/jobs/tag-pdm/
         regexp: ".*yml"
       - with_in: ci/utility/jobs/tag-payment-timelines/
+        regexp: ".*yml"
+      - with_in: ci/utility/jobs/tag-clive/
         regexp: ".*yml"
     to: aviator_pipeline_object_tagging.yml
 fly:

--- a/batch_object_tagger.tf
+++ b/batch_object_tagger.tf
@@ -7,6 +7,7 @@ locals {
   config_filename                    = "data_classification.csv"
   data_s3_prefix                     = "data/uc/uc.db"
   pt_s3_prefix                       = "data/uc_payment_timelines"
+  clive_s3_prefix                    = "data/uc_clive"
 }
 
 # AWS Batch Job IAM role

--- a/ci/utility/groups.yml
+++ b/ci/utility/groups.yml
@@ -1,35 +1,4 @@
 groups:
-  - name: pdm-object-tagging
-    jobs:
-    - pdm-object-tagging-dev
-    - pdm-object-tagging-qa
-    - pdm-object-tagging-integration
-    - pdm-object-tagging-preprod
-    - pdm-object-tagging-production
-    - pdm-rbac-csv-upload-dev
-    - pdm-rbac-csv-upload-qa
-    - pdm-rbac-csv-upload-integration
-    - pdm-rbac-csv-upload-preprod
-    - pdm-rbac-csv-upload-production
-  - name: pt-object-tagging
-    jobs:
-      - pt-object-tagging-dev
-      - pt-object-tagging-qa
-      - pt-object-tagging-integration
-      - pt-object-tagging-preprod
-      - pt-object-tagging-production
-      - pt-rbac-csv-upload-dev
-      - pt-rbac-csv-upload-qa
-      - pt-rbac-csv-upload-integration
-      - pt-rbac-csv-upload-preprod
-      - pt-rbac-csv-upload-production
-  - name: clive-object-tagging
-    jobs:
-      - clive-object-tagging-dev
-      - clive-object-tagging-qa
-      - clive-object-tagging-integration
-      - clive-object-tagging-preprod
-      - clive-object-tagging-production
   - name: rbac-csv-upload
     jobs:
       - rbac-csv-upload-dev
@@ -37,3 +6,24 @@ groups:
       - rbac-csv-upload-integration
       - rbac-csv-upload-preprod
       - rbac-csv-upload-production
+  - name: pdm-object-tagging
+    jobs:
+    - pdm-object-tagging-dev
+    - pdm-object-tagging-qa
+    - pdm-object-tagging-integration
+    - pdm-object-tagging-preprod
+    - pdm-object-tagging-production
+  - name: pt-object-tagging
+    jobs:
+      - pt-object-tagging-dev
+      - pt-object-tagging-qa
+      - pt-object-tagging-integration
+      - pt-object-tagging-preprod
+      - pt-object-tagging-production
+  - name: clive-object-tagging
+    jobs:
+      - clive-object-tagging-dev
+      - clive-object-tagging-qa
+      - clive-object-tagging-integration
+      - clive-object-tagging-preprod
+      - clive-object-tagging-production

--- a/ci/utility/groups.yml
+++ b/ci/utility/groups.yml
@@ -6,11 +6,11 @@ groups:
     - pdm-object-tagging-integration
     - pdm-object-tagging-preprod
     - pdm-object-tagging-production
-    - rbac-csv-upload-dev
-    - rbac-csv-upload-qa
-    - rbac-csv-upload-integration
-    - rbac-csv-upload-preprod
-    - rbac-csv-upload-production
+    - pdm-rbac-csv-upload-dev
+    - pdm-rbac-csv-upload-qa
+    - pdm-rbac-csv-upload-integration
+    - pdm-rbac-csv-upload-preprod
+    - pdm-rbac-csv-upload-production
   - name: pt-object-tagging
     jobs:
       - pt-object-tagging-dev
@@ -23,3 +23,15 @@ groups:
       - pt-rbac-csv-upload-integration
       - pt-rbac-csv-upload-preprod
       - pt-rbac-csv-upload-production
+  - name: clive-object-tagging
+    jobs:
+      - clive-object-tagging-dev
+      - clive-object-tagging-qa
+      - clive-object-tagging-integration
+      - clive-object-tagging-preprod
+      - clive-object-tagging-production
+      - clive-rbac-csv-upload-dev
+      - clive-rbac-csv-upload-qa
+      - clive-rbac-csv-upload-integration
+      - clive-rbac-csv-upload-preprod
+      - clive-rbac-csv-upload-production

--- a/ci/utility/groups.yml
+++ b/ci/utility/groups.yml
@@ -35,3 +35,10 @@ groups:
       - clive-rbac-csv-upload-integration
       - clive-rbac-csv-upload-preprod
       - clive-rbac-csv-upload-production
+  - name: rbac-csv-upload
+    jobs:
+      - rbac-csv-upload-dev
+      - rbac-csv-upload-qa
+      - rbac-csv-upload-integration
+      - rbac-csv-upload-preprod
+      - rbac-csv-upload-production

--- a/ci/utility/groups.yml
+++ b/ci/utility/groups.yml
@@ -30,11 +30,6 @@ groups:
       - clive-object-tagging-integration
       - clive-object-tagging-preprod
       - clive-object-tagging-production
-      - clive-rbac-csv-upload-dev
-      - clive-rbac-csv-upload-qa
-      - clive-rbac-csv-upload-integration
-      - clive-rbac-csv-upload-preprod
-      - clive-rbac-csv-upload-production
   - name: rbac-csv-upload
     jobs:
       - rbac-csv-upload-dev

--- a/ci/utility/jobs/rbac-classification-upload/dev-rbac-classification.yml
+++ b/ci/utility/jobs/rbac-classification-upload/dev-rbac-classification.yml
@@ -7,9 +7,9 @@ jobs:
         trigger: true
       - get: aws-common-infrastructure
       - .: (( inject meta.plan.terraform-output-common ))
-      config:
-        params:
-          TF_WORKSPACE: default
+        config:
+          params:
+            TF_WORKSPACE: default
       - .: (( inject meta.plan.rbac-csv-upload ))
         config:
           params:

--- a/ci/utility/jobs/rbac-classification-upload/dev-rbac-classification.yml
+++ b/ci/utility/jobs/rbac-classification-upload/dev-rbac-classification.yml
@@ -7,6 +7,9 @@ jobs:
         trigger: true
       - get: aws-common-infrastructure
       - .: (( inject meta.plan.terraform-output-common ))
+      config:
+        params:
+          TF_WORKSPACE: default
       - .: (( inject meta.plan.rbac-csv-upload ))
         config:
           params:

--- a/ci/utility/jobs/rbac-classification-upload/dev-rbac-classification.yml
+++ b/ci/utility/jobs/rbac-classification-upload/dev-rbac-classification.yml
@@ -1,0 +1,13 @@
+jobs:
+  - name: rbac-csv-upload-dev
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+      - get: aws-common-infrastructure
+      - .: (( inject meta.plan.terraform-output-common ))
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci

--- a/ci/utility/jobs/rbac-classification-upload/integration-rbac-classification.yml
+++ b/ci/utility/jobs/rbac-classification-upload/integration-rbac-classification.yml
@@ -1,0 +1,20 @@
+jobs:
+  - name: rbac-csv-upload-integration
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+        - rbac-csv-upload-qa
+      - get: aws-common-infrastructure
+        passed:
+          - rbac-csv-upload-qa
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: integration
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci

--- a/ci/utility/jobs/rbac-classification-upload/preprod-rbac-classification.yml
+++ b/ci/utility/jobs/rbac-classification-upload/preprod-rbac-classification.yml
@@ -1,0 +1,21 @@
+jobs:
+  - name: rbac-csv-upload-preprod
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+        - rbac-csv-upload-qa
+      - get: aws-common-infrastructure
+        passed:
+          - rbac-csv-upload-qa
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: preprod
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
+

--- a/ci/utility/jobs/rbac-classification-upload/production-rbac-classification.yml
+++ b/ci/utility/jobs/rbac-classification-upload/production-rbac-classification.yml
@@ -1,0 +1,21 @@
+jobs:
+  - name: rbac-csv-upload-production
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+        - rbac-csv-upload-preprod
+      - get: aws-common-infrastructure
+        passed:
+          - rbac-csv-upload-preprod
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: production
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
+

--- a/ci/utility/jobs/rbac-classification-upload/qa-rbac-classification.yml
+++ b/ci/utility/jobs/rbac-classification-upload/qa-rbac-classification.yml
@@ -1,0 +1,17 @@
+jobs:
+  - name: rbac-csv-upload-qa
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+      - get: aws-common-infrastructure
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: qa
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
+

--- a/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
@@ -31,4 +31,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            OUTPUT_NAME: clive_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: clive_object_tagger_data_classification

--- a/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
@@ -31,4 +31,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUT_NAME: clive_object_tagger_data_classification

--- a/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
@@ -13,13 +13,13 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: default
+        config:
+          params:
+            TF_WORKSPACE: default
       - .: (( inject meta.plan.terraform-output-common ))
-      config:
-        params:
-          TF_WORKSPACE: default
+        config:
+          params:
+            TF_WORKSPACE: default
       - .: (( inject meta.plan.object-tagging-batch ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
@@ -13,7 +13,13 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: default
       - .: (( inject meta.plan.terraform-output-common ))
+      config:
+        params:
+          TF_WORKSPACE: default
       - .: (( inject meta.plan.object-tagging-batch ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
@@ -1,0 +1,34 @@
+jobs:
+  - name: clive-rbac-csv-upload-dev
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+      - get: aws-common-infrastructure
+      - .: (( inject meta.plan.terraform-output-common ))
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+
+  - name: clive-object-tagging-dev
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+          - clive-rbac-csv-upload-dev
+      - put: meta
+        resource: meta-development
+      - get: aws-common-infrastructure
+      - get: dataworks-aws-s3-object-tagger
+      - .: (( inject meta.plan.terraform-bootstrap ))
+      - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      - .: (( inject meta.plan.terraform-output-common ))
+      - .: (( inject meta.plan.object-tagging-batch ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
+            SUBSYSTEM: "PDM"

--- a/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/dev-clive-object-tagging.yml
@@ -1,17 +1,4 @@
 jobs:
-  - name: clive-rbac-csv-upload-dev
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-      - get: aws-common-infrastructure
-      - .: (( inject meta.plan.terraform-output-common ))
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-
   - name: clive-object-tagging-dev
     max_in_flight: 1
     serial: true
@@ -19,7 +6,7 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - clive-rbac-csv-upload-dev
+          - rbac-csv-upload-dev
       - put: meta
         resource: meta-development
       - get: aws-common-infrastructure

--- a/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: clive-rbac-csv-upload-integration
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - clive-rbac-csv-upload-qa
-      - get: aws-common-infrastructure
-        passed:
-          - clive-rbac-csv-upload-qa
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: integration
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-
   - name: clive-object-tagging-integration
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - clive-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
+          - clive-object-tagging-qa
       - put: meta
         resource: meta-integration
       - get: aws-common-infrastructure
         passed:
-          - clive-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
@@ -1,0 +1,46 @@
+jobs:
+  - name: clive-rbac-csv-upload-integration
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+        - clive-rbac-csv-upload-qa
+      - get: aws-common-infrastructure
+        passed:
+          - clive-rbac-csv-upload-qa
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: integration
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
+
+  - name: clive-object-tagging-integration
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+          - clive-rbac-csv-upload-integration
+      - put: meta
+        resource: meta-integration
+      - get: aws-common-infrastructure
+        passed:
+          - clive-rbac-csv-upload-integration
+      - get: dataworks-aws-s3-object-tagger
+      - .: (( inject meta.plan.terraform-bootstrap ))
+      - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: integration
+      - .: (( inject meta.plan.object-tagging-batch ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
+            SUBSYSTEM: "PDM"

--- a/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
@@ -16,6 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+        config:
+          params:
+            TF_WORKSPACE: integration
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/integration-clive-object-tagging.yml
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUTS_PREFIX_NAME: clive_object_tagger_data_classification

--- a/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: clive-rbac-csv-upload-preprod
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - clive-rbac-csv-upload-qa
-      - get: aws-common-infrastructure
-        passed:
-          - clive-rbac-csv-upload-qa
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: preprod
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-
   - name: clive-object-tagging-preprod
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - clive-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
+          - clive-object-tagging-qa
       - put: meta
         resource: meta-preprod
       - get: aws-common-infrastructure
         passed:
-          - clive-rbac-csv-upload-preprod
+          - rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUTS_PREFIX_NAME: clive_object_tagger_data_classification

--- a/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
@@ -1,0 +1,46 @@
+jobs:
+  - name: clive-rbac-csv-upload-preprod
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+        - clive-rbac-csv-upload-qa
+      - get: aws-common-infrastructure
+        passed:
+          - clive-rbac-csv-upload-qa
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: preprod
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
+
+  - name: clive-object-tagging-preprod
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+          - clive-rbac-csv-upload-integration
+      - put: meta
+        resource: meta-preprod
+      - get: aws-common-infrastructure
+        passed:
+          - clive-rbac-csv-upload-preprod
+      - get: dataworks-aws-s3-object-tagger
+      - .: (( inject meta.plan.terraform-bootstrap ))
+      - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: preprod
+      - .: (( inject meta.plan.object-tagging-batch ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
+            SUBSYSTEM: "PDM"

--- a/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
@@ -16,6 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: preprod
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/preprod-clive-object-tagging.yml
@@ -16,9 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: preprod
+        config:
+          params:
+            TF_WORKSPACE: preprod
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUTS_PREFIX_NAME: clive_object_tagger_data_classification

--- a/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
@@ -16,6 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: production
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
@@ -16,9 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: production
+        config:
+          params:
+            TF_WORKSPACE: production
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
@@ -1,0 +1,46 @@
+jobs:
+  - name: clive-rbac-csv-upload-production
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+        - clive-rbac-csv-upload-preprod
+      - get: aws-common-infrastructure
+        passed:
+          - clive-rbac-csv-upload-preprod
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: production
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
+
+  - name: clive-object-tagging-production
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+          - clive-rbac-csv-upload-production
+      - put: meta
+        resource: meta-production
+      - get: aws-common-infrastructure
+        passed:
+          - clive-rbac-csv-upload-preprod
+      - get: dataworks-aws-s3-object-tagger
+      - .: (( inject meta.plan.terraform-bootstrap ))
+      - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: production
+      - .: (( inject meta.plan.object-tagging-batch ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
+            SUBSYSTEM: "PDM"

--- a/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/production-clive-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: clive-rbac-csv-upload-production
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - clive-rbac-csv-upload-preprod
-      - get: aws-common-infrastructure
-        passed:
-          - clive-rbac-csv-upload-preprod
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: production
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-
   - name: clive-object-tagging-production
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - clive-rbac-csv-upload-production
+          - rbac-csv-upload-production
+          - clive-object-tagging-preprod
       - put: meta
         resource: meta-production
       - get: aws-common-infrastructure
         passed:
-          - clive-rbac-csv-upload-preprod
+          - rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
@@ -15,6 +15,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
@@ -39,4 +39,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUTS_PREFIX_NAME: clive_object_tagger_data_classification

--- a/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
@@ -15,9 +15,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: qa
+        config:
+          params:
+            TF_WORKSPACE: qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
@@ -1,0 +1,42 @@
+jobs:
+  - name: clive-rbac-csv-upload-qa
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+      - get: aws-common-infrastructure
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: qa
+      - .: (( inject meta.plan.rbac-csv-upload ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
+
+  - name: clive-object-tagging-qa
+    max_in_flight: 1
+    serial: true
+    plan:
+      - get: rbac-csv
+        trigger: true
+        passed:
+          - clive-rbac-csv-upload-qa
+      - put: meta
+        resource: meta-qa
+      - get: aws-common-infrastructure
+        passed:
+          - clive-rbac-csv-upload-qa
+      - get: dataworks-aws-s3-object-tagger
+      - .: (( inject meta.plan.terraform-bootstrap ))
+      - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      - .: (( inject meta.plan.terraform-output-common ))
+        config:
+          params:
+            TF_WORKSPACE: qa
+      - .: (( inject meta.plan.object-tagging-batch ))
+        config:
+          params:
+            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
+            SUBSYSTEM: "PDM"

--- a/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
+++ b/ci/utility/jobs/tag-clive/qa-clive-object-tagging.yml
@@ -1,20 +1,4 @@
 jobs:
-  - name: clive-rbac-csv-upload-qa
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-      - get: aws-common-infrastructure
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: qa
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-
   - name: clive-object-tagging-qa
     max_in_flight: 1
     serial: true
@@ -22,12 +6,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - clive-rbac-csv-upload-qa
+          - rbac-csv-upload-qa
       - put: meta
         resource: meta-qa
       - get: aws-common-infrastructure
         passed:
-          - clive-rbac-csv-upload-qa
+          - rbac-csv-upload-qa
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-payment-timelines/pt-dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-dev-object-tagging.yml
@@ -22,7 +22,7 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-dev
+          - pt-rbac-csv-upload-dev
       - put: meta
         resource: meta-development
       - get: aws-common-infrastructure
@@ -40,4 +40,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            OUTPUT_NAME: pt_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-dev-object-tagging.yml
@@ -40,4 +40,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            SUBSYSTEM: "PaymentTimelines"
+            OUTPUT_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-dev-object-tagging.yml
@@ -1,20 +1,4 @@
 jobs:
-  - name: pt-rbac-csv-upload-dev
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-      - get: aws-common-infrastructure
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-             TF_WORKSPACE: default
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-
   - name: pt-object-tagging-dev
     max_in_flight: 1
     serial: true
@@ -22,7 +6,7 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pt-rbac-csv-upload-dev
+          - rbac-csv-upload-dev
       - put: meta
         resource: meta-development
       - get: aws-common-infrastructure

--- a/ci/utility/jobs/tag-payment-timelines/pt-integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-integration-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: pt-rbac-csv-upload-integration
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - pt-rbac-csv-upload-qa
-      - get: aws-common-infrastructure
-        passed:
-          - pt-rbac-csv-upload-qa
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: integration
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-
   - name: pt-object-tagging-integration
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pt-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
+          - pt-object-tagging-qa
       - put: meta
         resource: meta-integration
       - get: aws-common-infrastructure
         passed:
-          - pt-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-payment-timelines/pt-integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-integration-object-tagging.yml
@@ -46,4 +46,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-            SUBSYSTEM: "PaymentTimelines"
+            OUTPUT_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-integration-object-tagging.yml
@@ -6,10 +6,10 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-        - rbac-csv-upload-qa
+        - pt-rbac-csv-upload-qa
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-qa
+          - pt-rbac-csv-upload-qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:
@@ -26,12 +26,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-integration
+          - pt-rbac-csv-upload-integration
       - put: meta
         resource: meta-integration
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-integration
+          - pt-rbac-csv-upload-integration
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -46,4 +46,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-            OUTPUT_NAME: pt_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-preprod-object-tagging.yml
@@ -6,10 +6,10 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-        - rbac-csv-upload-qa
+        - pt-rbac-csv-upload-qa
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-qa
+          - pt-rbac-csv-upload-qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:
@@ -26,12 +26,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-integration
+          - pt-rbac-csv-upload-integration
       - put: meta
         resource: meta-preprod
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-preprod
+          - pt-rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -46,4 +46,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-            OUTPUT_NAME: pt_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-preprod-object-tagging.yml
@@ -46,4 +46,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-            SUBSYSTEM: "PaymentTimelines"
+            OUTPUT_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-preprod-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: pt-rbac-csv-upload-preprod
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - pt-rbac-csv-upload-qa
-      - get: aws-common-infrastructure
-        passed:
-          - pt-rbac-csv-upload-qa
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: preprod
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-
   - name: pt-object-tagging-preprod
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pt-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
+          - pt-object-tagging-qa
       - put: meta
         resource: meta-preprod
       - get: aws-common-infrastructure
         passed:
-          - pt-rbac-csv-upload-preprod
+          - rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-payment-timelines/pt-production-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-production-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: pt-rbac-csv-upload-production
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - pt-rbac-csv-upload-preprod
-      - get: aws-common-infrastructure
-        passed:
-          - pt-rbac-csv-upload-preprod
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: production
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-
   - name: pt-object-tagging-production
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pt-rbac-csv-upload-production
+          - rbac-csv-upload-production
+          - pt-object-tagging-preprod
       - put: meta
         resource: meta-production
       - get: aws-common-infrastructure
         passed:
-          - pt-rbac-csv-upload-preprod
+          - rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-payment-timelines/pt-production-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-production-object-tagging.yml
@@ -46,4 +46,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-            SUBSYSTEM: "PaymentTimelines"
+            OUTPUT_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-production-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-production-object-tagging.yml
@@ -6,10 +6,10 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-        - rbac-csv-upload-preprod
+        - pt-rbac-csv-upload-preprod
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-preprod
+          - pt-rbac-csv-upload-preprod
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:
@@ -26,12 +26,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-production
+          - pt-rbac-csv-upload-production
       - put: meta
         resource: meta-production
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-preprod
+          - pt-rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -46,4 +46,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-            OUTPUT_NAME: pt_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-qa-object-tagging.yml
@@ -22,12 +22,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-qa
+          - pt-rbac-csv-upload-qa
       - put: meta
         resource: meta-qa
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-qa
+          - pt-rbac-csv-upload-qa
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -42,4 +42,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-            OUTPUT_NAME: pt_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-qa-object-tagging.yml
@@ -42,4 +42,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-            SUBSYSTEM: "PaymentTimelines"
+            OUTPUT_NAME: pt_object_tagger_data_classification

--- a/ci/utility/jobs/tag-payment-timelines/pt-qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-payment-timelines/pt-qa-object-tagging.yml
@@ -1,20 +1,4 @@
 jobs:
-  - name: pt-rbac-csv-upload-qa
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-      - get: aws-common-infrastructure
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: qa
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-
   - name: pt-object-tagging-qa
     max_in_flight: 1
     serial: true
@@ -22,12 +6,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pt-rbac-csv-upload-qa
+          - rbac-csv-upload-qa
       - put: meta
         resource: meta-qa
       - get: aws-common-infrastructure
         passed:
-          - pt-rbac-csv-upload-qa
+          - rbac-csv-upload-qa
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
@@ -31,4 +31,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUT_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
@@ -13,13 +13,13 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: default
+        config:
+          params:
+            TF_WORKSPACE: default
       - .: (( inject meta.plan.terraform-output-common ))
-      config:
-        params:
-          TF_WORKSPACE: default
+        config:
+          params:
+            TF_WORKSPACE: default
       - .: (( inject meta.plan.object-tagging-batch ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
@@ -1,17 +1,4 @@
 jobs:
-  - name: pdm-rbac-csv-upload-dev
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-      - get: aws-common-infrastructure
-      - .: (( inject meta.plan.terraform-output-common ))
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-
   - name: pdm-object-tagging-dev
     max_in_flight: 1
     serial: true
@@ -19,7 +6,7 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pdm-rbac-csv-upload-dev
+          - rbac-csv-upload-dev
       - put: meta
         resource: meta-development
       - get: aws-common-infrastructure

--- a/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
@@ -13,7 +13,13 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: default
       - .: (( inject meta.plan.terraform-output-common ))
+      config:
+        params:
+          TF_WORKSPACE: default
       - .: (( inject meta.plan.object-tagging-batch ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/dev-object-tagging.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: rbac-csv-upload-dev
+  - name: pdm-rbac-csv-upload-dev
     max_in_flight: 1
     serial: true
     plan:
@@ -19,7 +19,7 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-dev
+          - pdm-rbac-csv-upload-dev
       - put: meta
         resource: meta-development
       - get: aws-common-infrastructure
@@ -31,4 +31,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.development)):role/ci
-            OUTPUT_NAME: pdm_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: pdm-rbac-csv-upload-integration
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - pdm-rbac-csv-upload-qa
-      - get: aws-common-infrastructure
-        passed:
-          - pdm-rbac-csv-upload-qa
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: integration
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-
   - name: pdm-object-tagging-integration
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pdm-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
+          - pdm-object-tagging-qa
       - put: meta
         resource: meta-integration
       - get: aws-common-infrastructure
         passed:
-          - pdm-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
@@ -1,15 +1,15 @@
 jobs:
-  - name: rbac-csv-upload-integration
+  - name: pdm-rbac-csv-upload-integration
     max_in_flight: 1
     serial: true
     plan:
       - get: rbac-csv
         trigger: true
         passed:
-        - rbac-csv-upload-qa
+        - pdm-rbac-csv-upload-qa
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-qa
+          - pdm-rbac-csv-upload-qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:
@@ -26,12 +26,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-integration
+          - pdm-rbac-csv-upload-integration
       - put: meta
         resource: meta-integration
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-integration
+          - pdm-rbac-csv-upload-integration
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-            OUTPUT_NAME: pdm_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.integration)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUT_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
@@ -16,9 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: integration
+        config:
+          params:
+            TF_WORKSPACE: integration
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/integration-object-tagging.yml
@@ -16,6 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: integration
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUT_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
@@ -1,15 +1,15 @@
 jobs:
-  - name: rbac-csv-upload-preprod
+  - name: pdm-rbac-csv-upload-preprod
     max_in_flight: 1
     serial: true
     plan:
       - get: rbac-csv
         trigger: true
         passed:
-        - rbac-csv-upload-qa
+        - pdm-rbac-csv-upload-qa
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-qa
+          - pdm-rbac-csv-upload-qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:
@@ -26,12 +26,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-integration
+          - pdm-rbac-csv-upload-integration
       - put: meta
         resource: meta-preprod
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-preprod
+          - pdm-rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-            OUTPUT_NAME: pdm_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
@@ -16,6 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: preprod
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: pdm-rbac-csv-upload-preprod
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - pdm-rbac-csv-upload-qa
-      - get: aws-common-infrastructure
-        passed:
-          - pdm-rbac-csv-upload-qa
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: preprod
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.preprod)):role/ci
-
   - name: pdm-object-tagging-preprod
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pdm-rbac-csv-upload-integration
+          - rbac-csv-upload-integration
+          - pdm-object-tagging-qa
       - put: meta
         resource: meta-preprod
       - get: aws-common-infrastructure
         passed:
-          - pdm-rbac-csv-upload-preprod
+          - rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/preprod-object-tagging.yml
@@ -16,9 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: preprod
+        config:
+          params:
+            TF_WORKSPACE: preprod
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/production-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/production-object-tagging.yml
@@ -1,24 +1,4 @@
 jobs:
-  - name: pdm-rbac-csv-upload-production
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-        passed:
-        - pdm-rbac-csv-upload-preprod
-      - get: aws-common-infrastructure
-        passed:
-          - pdm-rbac-csv-upload-preprod
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: production
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-
   - name: pdm-object-tagging-production
     max_in_flight: 1
     serial: true
@@ -26,12 +6,13 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pdm-rbac-csv-upload-production
+          - rbac-csv-upload-production
+          - pdm-object-tagging-preprod
       - put: meta
         resource: meta-production
       - get: aws-common-infrastructure
         passed:
-          - pdm-rbac-csv-upload-preprod
+          - rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/jobs/tag-pdm/production-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/production-object-tagging.yml
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUT_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/production-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/production-object-tagging.yml
@@ -1,15 +1,15 @@
 jobs:
-  - name: rbac-csv-upload-production
+  - name: pdm-rbac-csv-upload-production
     max_in_flight: 1
     serial: true
     plan:
       - get: rbac-csv
         trigger: true
         passed:
-        - rbac-csv-upload-preprod
+        - pdm-rbac-csv-upload-preprod
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-preprod
+          - pdm-rbac-csv-upload-preprod
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:
@@ -26,12 +26,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-production
+          - pdm-rbac-csv-upload-production
       - put: meta
         resource: meta-production
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-preprod
+          - pdm-rbac-csv-upload-preprod
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -43,4 +43,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.production)):role/ci
-            OUTPUT_NAME: pdm_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/production-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/production-object-tagging.yml
@@ -16,6 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: production
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/production-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/production-object-tagging.yml
@@ -16,9 +16,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: production
+        config:
+          params:
+            TF_WORKSPACE: production
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
@@ -15,6 +15,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
+      config:
+        params:
+          TF_WORKSPACE: qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
@@ -39,4 +39,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-            SUBSYSTEM: "PDM"
+            OUTPUT_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
@@ -15,9 +15,9 @@ jobs:
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
-      config:
-        params:
-          TF_WORKSPACE: qa
+        config:
+          params:
+            TF_WORKSPACE: qa
       - .: (( inject meta.plan.terraform-output-common ))
         config:
           params:

--- a/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: rbac-csv-upload-qa
+  - name: pdm-rbac-csv-upload-qa
     max_in_flight: 1
     serial: true
     plan:
@@ -22,12 +22,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - rbac-csv-upload-qa
+          - pdm-rbac-csv-upload-qa
       - put: meta
         resource: meta-qa
       - get: aws-common-infrastructure
         passed:
-          - rbac-csv-upload-qa
+          - pdm-rbac-csv-upload-qa
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))
@@ -39,4 +39,4 @@ jobs:
         config:
           params:
             AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-            OUTPUT_NAME: pdm_object_tagger_data_classification
+            OUTPUTS_PREFIX_NAME: pdm_object_tagger_data_classification

--- a/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
+++ b/ci/utility/jobs/tag-pdm/qa-object-tagging.yml
@@ -1,20 +1,4 @@
 jobs:
-  - name: pdm-rbac-csv-upload-qa
-    max_in_flight: 1
-    serial: true
-    plan:
-      - get: rbac-csv
-        trigger: true
-      - get: aws-common-infrastructure
-      - .: (( inject meta.plan.terraform-output-common ))
-        config:
-          params:
-            TF_WORKSPACE: qa
-      - .: (( inject meta.plan.rbac-csv-upload ))
-        config:
-          params:
-            AWS_ROLE_ARN: arn:aws:iam::((aws_account.qa)):role/ci
-
   - name: pdm-object-tagging-qa
     max_in_flight: 1
     serial: true
@@ -22,12 +6,12 @@ jobs:
       - get: rbac-csv
         trigger: true
         passed:
-          - pdm-rbac-csv-upload-qa
+          - rbac-csv-upload-qa
       - put: meta
         resource: meta-qa
       - get: aws-common-infrastructure
         passed:
-          - pdm-rbac-csv-upload-qa
+          - rbac-csv-upload-qa
       - get: dataworks-aws-s3-object-tagger
       - .: (( inject meta.plan.terraform-bootstrap ))
       - .: (( inject meta.plan.terraform-output-aws-s3-object-tagger ))

--- a/ci/utility/meta.yml
+++ b/ci/utility/meta.yml
@@ -122,9 +122,9 @@ meta:
             - |
               # Change these values in the batch_object_tagger.tf file
               echo "Using output name ${OUTPUTS_PREFIX_NAME}"
-              DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUTS_PREFIX_NAME}.value.data_s3_prefix' )
-              CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUTS_PREFIX_NAME}.value.config_prefix' )
-              FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUTS_PREFIX_NAME}.value.config_file' )
+              DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r ".$OUTPUTS_PREFIX_NAME.value.data_s3_prefix" )
+              CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r ".$OUTPUTS_PREFIX_NAME.value.config_prefix" )
+              FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r ".$OUTPUTS_PREFIX_NAME.value.config_file" )
 
               source /assume-role
               pipeline_name=`cat "meta/build_pipeline_name"`

--- a/ci/utility/meta.yml
+++ b/ci/utility/meta.yml
@@ -121,10 +121,10 @@ meta:
             - -exc
             - |
               # Change these values in the batch_object_tagger.tf file
-              echo "Using output name ${OUTPUT_NAME}"
-              DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUT_NAME}.value.data_s3_prefix' )
-              CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUT_NAME}.value.config_prefix' )
-              FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUT_NAME}.value.config_file' )
+              echo "Using output name ${OUTPUTS_PREFIX_NAME}"
+              DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUTS_PREFIX_NAME}.value.data_s3_prefix' )
+              CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUTS_PREFIX_NAME}.value.config_prefix' )
+              FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUTS_PREFIX_NAME}.value.config_file' )
 
               source /assume-role
               pipeline_name=`cat "meta/build_pipeline_name"`

--- a/ci/utility/meta.yml
+++ b/ci/utility/meta.yml
@@ -123,8 +123,11 @@ meta:
               # Change these values in the batch_object_tagger.tf file
               echo "Using output name ${OUTPUTS_PREFIX_NAME}"
               DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r ".$OUTPUTS_PREFIX_NAME.value.data_s3_prefix" )
+              echo "DATA_S3_PREFIX: ${DATA_S3_PREFIX}"
               CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r ".$OUTPUTS_PREFIX_NAME.value.config_prefix" )
+              echo "CSV_PREFIX: ${CSV_PREFIX}"
               FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r ".$OUTPUTS_PREFIX_NAME.value.config_file" )
+              echo "FILE_NAME: ${FILE_NAME}"
 
               source /assume-role
               pipeline_name=`cat "meta/build_pipeline_name"`

--- a/ci/utility/meta.yml
+++ b/ci/utility/meta.yml
@@ -121,17 +121,11 @@ meta:
             - -exc
             - |
               # Change these values in the batch_object_tagger.tf file
-              if [[ "${SUBSYSTEM}" == "PDM" ]];
-              then
-                  DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.pdm_object_tagger_data_classification.value.data_s3_prefix' )
-                  CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.pdm_object_tagger_data_classification.value.config_prefix' )
-                  FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.pdm_object_tagger_data_classification.value.config_file' )
-              elif [[ "${SUBSYSTEM}" == "PaymentTimelines" ]];
-              then
-                  DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.pt_object_tagger_data_classification.value.data_s3_prefix' )
-                  CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.pt_object_tagger_data_classification.value.config_prefix' )
-                  FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.pt_object_tagger_data_classification.value.config_file' )
-              fi
+              echo "Using output name ${OUTPUT_NAME}"
+              DATA_S3_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUT_NAME}.value.data_s3_prefix' )
+              CSV_PREFIX=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUT_NAME}.value.config_prefix' )
+              FILE_NAME=$(cat terraform-output-aws-s3-object-tagger/outputs.json | jq -r '.${OUTPUT_NAME}.value.config_file' )
+
               source /assume-role
               pipeline_name=`cat "meta/build_pipeline_name"`
               job_name=`cat "meta/build_job_name"`

--- a/ci/utility/resources.yml
+++ b/ci/utility/resources.yml
@@ -8,6 +8,7 @@ resources:
       password: ((dataworks-secrets.enterprise_github_pat))
     check_every: 5m
     webhook_token: ((dataworks.concourse_github_webhook_token))
+
   - name: rbac-csv
     type: git
     source:
@@ -19,6 +20,7 @@ resources:
         - data/data_classification.csv
     webhook_token: ((dataworks.concourse_github_webhook_token))
     check_every: 5m
+
   - name: dataworks-aws-s3-object-tagger
     type: git
     source:
@@ -27,13 +29,18 @@ resources:
       access_token: ((dataworks-secrets.concourse_github_pat))
     webhook_token: ((dataworks.concourse_github_webhook_token))
     check_every: 720h
+
   - name: meta-development
     type: meta
+
   - name: meta-qa
     type: meta
+
   - name: meta-integration
     type: meta
+
   - name: meta-preprod
     type: meta
+
   - name: meta-production
     type: meta

--- a/output.tf
+++ b/output.tf
@@ -24,3 +24,11 @@ output "pt_object_tagger_data_classification" {
     data_s3_prefix = local.pt_s3_prefix
   }
 }
+
+output "clive_object_tagger_data_classification" {
+  value = {
+    config_prefix  = local.config_prefix
+    config_file    = local.config_filename
+    data_s3_prefix = local.clive_s3_prefix
+  }
+}


### PR DESCRIPTION
- Create Clive object tagging pipelines
- Create separate group for RBAC CSV upload jobs
- Modify all pipelines to use single RBAC CSV upload and not duplicate the code
- Modify meta to accept output name to differentiate each object tagging pipeline rather than an if block.